### PR TITLE
Check sysctl settings before check

### DIFF
--- a/tests/fixtures/centos_fail.txt
+++ b/tests/fixtures/centos_fail.txt
@@ -134,6 +134,8 @@ net.ipv4.ip_forward
 Disabled:
 net.bridge.bridge-nf-call-ip6tables
 net.bridge.bridge-nf-call-iptables
+
+Skipped:
 fs.may_detach_mounts
 
 Sysctl Result: FAIL

--- a/tests/fixtures/command_returns.py
+++ b/tests/fixtures/command_returns.py
@@ -140,6 +140,21 @@ def lsmod_return():
     ).encode('utf-8')
 
 
+def all_sysctl_return(skipped=False):
+    if skipped:
+        return (
+            'vm.overcommit_memory = 0\nnet.bridge.bridge-nf-call-ip6tables = 0'
+            '\nnet.bridge.bridge-nf-call-iptables = 0'
+            '\nnet.ipv4.ip_forward = 1\n'
+        ).encode('utf-8')
+    else:
+        return (
+            'vm.overcommit_memory = 0\nnet.bridge.bridge-nf-call-ip6tables = 0'
+            '\nnet.bridge.bridge-nf-call-iptables = 0'
+            '\nfs.may_detach_mounts = 1\nnet.ipv4.ip_forward = 1\n'
+        ).encode('utf-8')
+
+
 def get_pid(pid, name):
     class PidInfoTest():
         def __init__(self, pid, name):

--- a/tests/fixtures/reporting_returns.py
+++ b/tests/fixtures/reporting_returns.py
@@ -204,14 +204,17 @@ def sysctl(test_pass=True):
                 'fs.may_detach_mounts',
                 'net.ipv4.ip_forward'
             ],
-            'disabled': []
+            'disabled': [],
+            'skipped': []
         }
 
     return {
         'enabled': ['net.ipv4.ip_forward'],
         'disabled': [
             'net.bridge.bridge-nf-call-ip6tables',
-            'net.bridge.bridge-nf-call-iptables',
+            'net.bridge.bridge-nf-call-iptables'
+        ],
+        'skipped': [
             'fs.may_detach_mounts'
         ]
     }

--- a/tests/fixtures/suse_fail.txt
+++ b/tests/fixtures/suse_fail.txt
@@ -140,6 +140,8 @@ net.ipv4.ip_forward
 Disabled:
 net.bridge.bridge-nf-call-ip6tables
 net.bridge.bridge-nf-call-iptables
+
+Skipped:
 fs.may_detach_mounts
 
 Sysctl Result: FAIL

--- a/tests/tests_system_gather.py
+++ b/tests/tests_system_gather.py
@@ -577,13 +577,43 @@ class TestSystemProfile(TestCase):
                 'net.bridge.bridge-nf-call-ip6tables',
                 'net.bridge.bridge-nf-call-iptables',
                 'fs.may_detach_mounts'
-            ]
+            ],
+            'skipped': []
         }
         mock_response = mock.Mock()
         mock_response.side_effect = [
+            command_returns.all_sysctl_return(),
             b'net.bridge.bridge-nf-call-ip6tables = 0',
             b'net.bridge.bridge-nf-call-iptables = 0',
             b'',
+            b'net.ipv4.ip_forward = 1'
+        ]
+        with mock.patch(
+            'system_profile.profile.execute_command',
+            side_effect=mock_response
+        ):
+            returns = profile.check_sysctl(True)
+
+        self.assertEquals(
+            expected_output,
+            returns,
+            'Returned values did not match expected output'
+        )
+
+    def test_sysctl_settings_skipped(self):
+        expected_output = {
+            'enabled': ['net.ipv4.ip_forward'],
+            'disabled': [
+                'net.bridge.bridge-nf-call-ip6tables',
+                'net.bridge.bridge-nf-call-iptables'
+            ],
+            'skipped': ['fs.may_detach_mounts']
+        }
+        mock_response = mock.Mock()
+        mock_response.side_effect = [
+            command_returns.all_sysctl_return(skipped=True),
+            b'net.bridge.bridge-nf-call-ip6tables = 0',
+            b'net.bridge.bridge-nf-call-iptables = 0',
             b'net.ipv4.ip_forward = 1'
         ]
         with mock.patch(


### PR DESCRIPTION
- Grab all sysctl settings available to set and then check if the setting is even available to set.
- Report sysctl settings not able to be set as skipped