### PR TITLE
Update travis and fix issue with Ubuntu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: python
-python:
-  - "2.7"
-  - "3.5"
-  - "3.6"
-  - "3.7"
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
+      dist: xenial
+      sudo: true
 install:
   - pip install -e .[tests]
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7-dev"
+  - "3.7"
 install:
   - pip install -e .[tests]
 before_script:

--- a/ae_preflight/profile.py
+++ b/ae_preflight/profile.py
@@ -140,9 +140,34 @@ def get_os_info(verbose):
 
         profile['distribution'] = distribution
         linux_info = {
-            'version_id': temp_info[1],
             'name': temp_info[0]
         }
+
+        # Because of how platform works have to read /etc/lsb-release and get
+        # info from it as well to ensure we have the right info
+        if linux_info.get('name') == 'debian':
+            lsb_content = None
+            with open('/etc/lsb-release') as f:
+                lsb_content = f.read()
+
+            # Grab the data from lsb-release content
+            if lsb_content:
+                linux_info['version_id'] = (
+                    re.search('DISTRIB_RELEASE=(.+?)\n', lsb_content).group(1)
+                )
+                distribution = (
+                    re.search('DISTRIB_ID=(.+?)\n', lsb_content).group(1)
+                )
+
+            # Reset distribution from lsb-release file
+            if distribution:
+                profile['distribution'] = distribution.lower()
+
+            # Manually set the name
+            linux_info['name'] = 'Ubuntu'
+        else:
+            linux_info['version_id'] = temp_info[1]
+
         version = 'UNK'
         if linux_info.get('version_id'):
             temp_version = linux_info.get('version_id').split('.')

--- a/tests/fixtures/command_returns.py
+++ b/tests/fixtures/command_returns.py
@@ -50,7 +50,7 @@ def distro_release_info(os):
         if os == 'centos':
             return_value = ('CentOS Linux', '7.5.1804', 'core')
         elif os == 'ubuntu':
-            return_value = ('Ubuntu', '16.04', 'xenial')
+            return_value = ('debian', 'stretch/sid', '')
         elif os == 'suse':
             return_value = ('SUSE Linux Enterprise Server', '12', 'x86_64')
 

--- a/tests/tests_system_gather.py
+++ b/tests/tests_system_gather.py
@@ -283,6 +283,12 @@ class TestSystemProfile(TestCase):
         }
         mock_response = mock.Mock()
         mock_response.side_effect = [False, True]
+        lsb_return = (
+            'DISTRIB_ID=Ubuntu\nDISTRIB_RELEASE=16.04\n'
+            'DISTRIB_CODENAME=xenial\nDISTRIB_DESCRIPTION="'
+            'Ubuntu 16.04.6 LTS"\n'
+        )
+        mocked_open = mock.mock_open(read_data=lsb_return)
 
         with mock.patch('tests.fixtures.command_returns.sys') as v_info:
             v_info.version_info = (3, 7, 0, 'final', 0)
@@ -294,11 +300,12 @@ class TestSystemProfile(TestCase):
                     os.return_value = command_returns.distro_release_info(
                         'ubuntu'
                     )
-                    with mock.patch(
-                        'ae_preflight.profile.os.path.isfile',
-                        side_effect=mock_response
-                    ):
-                        os_info = profile.get_os_info(True)
+                    with mock.patch('ae_preflight.profile.open', mocked_open):
+                        with mock.patch(
+                            'ae_preflight.profile.os.path.isfile',
+                            side_effect=mock_response
+                        ):
+                            os_info = profile.get_os_info(True)
 
         self.assertEquals(
             expected_output,


### PR DESCRIPTION
- Update how OS info is obtained on Ubuntu as it needs to use the /etc/lsb-release file
- Update travis to only include 2.7, 3.5, 3.6, and 3.7 python versions